### PR TITLE
add property "listViewAdjustContentInsets" on RefreshableListView

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,18 @@ In action (from [ReactNativeHackerNews](https://github.com/jsdf/ReactNativeHacke
 
 ![React Native Hacker News](http://i.imgur.com/gVmrxDe.png)
 
+### installation
+
+```bash
+npm install react-native-refreshable-listview --save
+```
+
 ### usage
 
 props:
 
-- `loadData`: a function returning a promise or taking a callback, invoked 
-  upon pulldown. spinner will show until the promise resolves or the 
+- `loadData`: a function returning a promise or taking a callback, invoked
+  upon pulldown. spinner will show until the promise resolves or the
   callback is called.
 - `refreshDescription`: text/element to show alongside spinner.
 

--- a/RefreshableListView.js
+++ b/RefreshableListView.js
@@ -22,11 +22,13 @@ var RefreshableListView = React.createClass({
     activityIndicatorComponent: PropTypes.func,
     stylesheet: PropTypes.object,
     refreshDescription: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    listViewAdjustContentInsets: React.PropTypes.bool,
   },
   getDefaultProps() {
     return {
       activityIndicatorComponent: ActivityIndicatorIOS,
       minDisplayTime: 300,
+      listViewAdjustContentInsets: true,
     }
   },
   getInitialState() {
@@ -94,6 +96,7 @@ var RefreshableListView = React.createClass({
         ref="listview"
         onScroll={this.handleScroll}
         renderHeader={this.renderHeader}
+        automaticallyAdjustContentInsets={this.props.listViewAdjustContentInsets}
       />
     )
   },


### PR DESCRIPTION
To avoid get a space before the first line of the ListView, we can set to false the "automaticallyAdjustContentInsets" property on the ListView component, and the space will disappear.

The property "listViewAdjustContentInsets" have been added to forward the value from the "RefreshableListView" component and the "ListView" component.