### PR TITLE
Only refresh when the user's finger is pressed.

### DIFF
--- a/lib/ControlledRefreshableListView.js
+++ b/lib/ControlledRefreshableListView.js
@@ -26,10 +26,15 @@ var ControlledRefreshableListView = React.createClass({
       refreshingIndictatorComponent: RefreshingIndicator,
     }
   },
+  getInitialState() {
+    return {
+      fingerPressed: false,
+    }
+  },
   handleScroll(e) {
     var scrollY = e.nativeEvent.contentInset.top + e.nativeEvent.contentOffset.y
 
-    if (scrollY < -this.props.minPulldownDistance) {
+    if (this.state.fingerPressed && scrollY < -this.props.minPulldownDistance) {
       if (!this.props.isRefreshing) {
         if (this.props.onRefresh) {
           this.props.onRefresh()
@@ -69,6 +74,8 @@ var ControlledRefreshableListView = React.createClass({
         onScroll={this.handleScroll}
         renderHeader={this.renderHeader}
         scrollEventThrottle={SCROLL_EVENT_THROTTLE}
+        onResponderGrant={() => this.setState({fingerPressed: true})}
+        onResponderRelease={() => this.setState({fingerPressed: false})}
       />
     )
   },


### PR DESCRIPTION
This avoids refreshes happening during the inertial scrolling by keeping track of if the user has a finger pressed, and only triggering the refresh if they do.