### PR TITLE
Fix pull to refresh logic

### DIFF
--- a/lib/ControlledRefreshableListView.js
+++ b/lib/ControlledRefreshableListView.js
@@ -13,6 +13,7 @@ const LISTVIEW_REF = 'listview'
 
 var ControlledRefreshableListView = React.createClass({
   propTypes: {
+    resolveScroll: PropTypes.func.isRequired,
     onRefresh: PropTypes.func.isRequired,
     isRefreshing: PropTypes.bool.isRequired,
     refreshDescription: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
@@ -37,7 +38,16 @@ var ControlledRefreshableListView = React.createClass({
   handleScroll(e) {
     var scrollY = e.nativeEvent.contentInset.top + e.nativeEvent.contentOffset.y
 
-    if (!(this.props.ignoreInertialScroll && this.isTouching)) {
+    if (scrollY == 0 && this.scrollingUp && !this.isTouching) {
+      this.scrollingUp = false;
+      if (this.props.resolveScroll) {
+        this.props.resolveScroll();
+      }
+    } else if (scrollY < 0 && scrollY > -this.props.minPulldownDistance && !this.scrollingUp) {
+      this.scrollingUp = true;
+    }
+
+    if (!this.props.ignoreInertialScroll || this.isTouching) {
       if (scrollY < -this.props.minPulldownDistance) {
         if (!this.props.isRefreshing) {
           if (this.props.onRefresh) {

--- a/lib/RefreshableListView.js
+++ b/lib/RefreshableListView.js
@@ -29,6 +29,11 @@ var RefreshableListView = React.createClass({
       refreshingIndictatorComponent: RefreshingIndicator,
     }
   },
+  _resolveScroll() {
+    if (this.resolveScroll) {
+      this.resolveScroll();
+    }
+  },
   getInitialState() {
     return {
       isRefreshing: false,
@@ -49,6 +54,9 @@ var RefreshableListView = React.createClass({
       Promise.all([
         loadingDataPromise,
         new Promise((resolve) => this.setState({isRefreshing: true}, resolve)),
+        new Promise((resolve) => {
+          this.resolveScroll = resolve;
+        }),
         delay(this.props.minDisplayTime),
       ])
         .then(() => delay(this.props.minBetweenTime))
@@ -71,6 +79,7 @@ var RefreshableListView = React.createClass({
         ref={LISTVIEW_REF}
         onRefresh={this.handleRefresh}
         isRefreshing={this.state.isRefreshing}
+        resolveScroll={this._resolveScroll}
       />
     )
   },


### PR DESCRIPTION
This fix contains a fix for this issue: https://github.com/jsdf/react-native-refreshable-listview/issues/16
It also keeps the list refreshing until the user is not touching. Without this fix, one could pull & hold and the refresh function would be triggered multiple times.