### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This component is more suitable for use in a [Redux](https://github.com/rackt/re
 ```js
 var React = require('react-native')
 var {Text, View, ListView} = React
-var {ControlledRefreshableListView} = require('react-native-refreshable-listview')
+var ControlledRefreshableListView = require('react-native-refreshable-listview/lib/ControlledRefreshableListView')
 
 var ArticleView = require('./ArticleView')
 


### PR DESCRIPTION
Fix require statement for ControlledRefreshableListView

`react-native-refreshable-listview` does not seem to export `ControlledRefreshableListView` as mentioned in #37. This updates the README with aforty's recommendation from that issue.
