### PR TITLE
React Native 0.28 update

### DIFF
--- a/lib/ControlledRefreshableListView.js
+++ b/lib/ControlledRefreshableListView.js
@@ -1,11 +1,13 @@
-var React = require('react-native')
+var React = require('react')
 var {
-  PropTypes,
+  PropTypes
+} = React;
+var {
   StyleSheet,
   View,
   Platform,
   PullToRefreshViewAndroid,
-} = React
+} = require('react-native')
 var ListView = require('./ListView')
 var createElementFrom = require('./createElementFrom')
 var RefreshingIndicator = require('./RefreshingIndicator')

--- a/lib/RefreshableListView.js
+++ b/lib/RefreshableListView.js
@@ -1,4 +1,4 @@
-var React = require('react-native')
+var React = require('react')
 var {
   PropTypes,
 } = React

--- a/lib/RefreshingIndicator.js
+++ b/lib/RefreshingIndicator.js
@@ -1,13 +1,15 @@
-var React = require('react-native')
+var React = require('react')
+var {
+  isValidElement,
+  createElement,
+  PropTypes,
+} = React;
 var {
   View,
   Text,
   ActivityIndicator,
-  PropTypes,
-  StyleSheet,
-  isValidElement,
-  createElement,
-} = React
+  StyleSheet
+} = require('react-native')
 
 var RefreshingIndicator = React.createClass({
   propTypes: {

--- a/lib/RefreshingIndicator.js
+++ b/lib/RefreshingIndicator.js
@@ -2,7 +2,7 @@ var React = require('react-native')
 var {
   View,
   Text,
-  ActivityIndicatorIOS,
+  ActivityIndicator,
   PropTypes,
   StyleSheet,
   isValidElement,
@@ -25,7 +25,7 @@ var RefreshingIndicator = React.createClass({
   },
   getDefaultProps() {
     return {
-      activityIndicatorComponent: ActivityIndicatorIOS,
+      activityIndicatorComponent: ActivityIndicator,
       isTouching: false,
       isRefreshing: false,
       isWaitingForRelease: false,

--- a/lib/createElementFrom.js
+++ b/lib/createElementFrom.js
@@ -1,4 +1,4 @@
-var React = require('react-native')
+var React = require('react')
 var {
   cloneElement,
   createElement,


### PR DESCRIPTION
Updates the module to work correctly under RN v0.28. The main breaking change was that RN no longer permits 'react-native' as an alias for 'react'. Also, ActivityIndicatorIOS has been deprecated in favor of the more general ActivityIndicator.

This resolves issues #58, #54.

Note: long-term, this module should be deprecated in favor of https://facebook.github.io/react-native/docs/refreshcontrol.html - for those who are stuck with it as a dependency for now, though, this PR should allow you to run the latest version of React Native until you get around to migrating to the native solution :)